### PR TITLE
Set default countdown to 10s

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
   </div>
 
   <script>
-    const targetDate = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+    const targetDate = new Date(Date.now() + 10 * 1000);
     let winnerAnnounced = false;
     const countdownInterval = setInterval(updateCountdown, 1000);
     updateCountdown();


### PR DESCRIPTION
## Summary
- shorted the default countdown timer to 10 seconds so the winner animation is easier to preview

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68605681a34c832e922e64b2cedc95d2