### PR TITLE
Make wheel responsive on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,10 +14,11 @@
     @keyframes fadeInBounce { 0% { opacity: 0; transform: translateY(-10px); } 50% { opacity: 1; transform: translateY(5px); } 100% { transform: translateY(0); } }
     #countdown { font-size: 1.5em; display: flex; justify-content: center; gap: 0.5em; margin-bottom: 1em; }
     .time { background: rgba(255,255,255,0.1); padding: 0.6em; border-radius: 10px; box-shadow: 0 0 10px #8e44ad; }
-    .boulier-visual { margin: 1em auto 0; width: 500px; height: 500px; background: url('/mnt/data/d9f5e889-6407-4368-b7fc-2f4808b99ee5.png') no-repeat center center; background-size: contain; position: relative; overflow: hidden; border-radius: 50%; box-shadow: inset 0 0 40px rgba(255,255,255,0.4), 0 0 50px rgba(142,68,173,0.7); }
+    .boulier-visual { margin: 1em auto 0; width: 100%; max-width: 500px; aspect-ratio: 1; background: url('/mnt/data/d9f5e889-6407-4368-b7fc-2f4808b99ee5.png') no-repeat center center; background-size: contain; position: relative; overflow: hidden; border-radius: 50%; box-shadow: inset 0 0 40px rgba(255,255,255,0.4), 0 0 50px rgba(142,68,173,0.7); }
     .boulier-base {
       margin: 0 auto;
-      width: 500px;
+      width: 100%;
+      max-width: 500px;
       height: 80px;
       background: #2c0039;
       box-shadow: inset 0 0 40px rgba(255,255,255,0.4), 0 0 50px rgba(142,68,173,0.7);
@@ -163,11 +164,18 @@
     }
 
     const boulier = document.getElementById('boulier');
-    const centerX = 250, centerY = 250, radius = 250, ballRadius = 15, speed = 4;
+
+const centerX = boulier.clientWidth / 2;
+const centerY = boulier.clientHeight / 2;
+const radius = centerX;
+let ballRadius = boulier.clientWidth * 0.03;
+const speed = 4;
     const balls = [];
     for (let i = 1; i <= 15; i++) {
       const ball = document.createElement('div');
       ball.className = 'ball';
+      ball.style.width = (ballRadius * 2) + "px";
+      ball.style.height = (ballRadius * 2) + "px";
       ball.textContent = i;
       ball.style.left = (centerX - ballRadius) + 'px';
       ball.style.top = (centerY - ballRadius) + 'px';


### PR DESCRIPTION
## Summary
- update the boule animation container style to scale with screen size
- scale base section width
- compute dimensions for the animation from the DOM and size the balls accordingly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871a7440688832e9cceac77eb582cfa