### PR TITLE
feat: schedule next giveaway for Sunday evenings

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,7 +151,19 @@
   </div>
 
   <script>
-    let targetDate = new Date(Date.UTC(2025, 7, 4, 0, 0, 0));
+    function getNextSunday8pm() {
+      const now = new Date();
+      const result = new Date(now);
+      const day = result.getDay();
+      const diff = (7 - day) % 7;
+      result.setDate(result.getDate() + diff);
+      result.setHours(20, 0, 0, 0);
+      if (diff === 0 && now.getHours() >= 20) {
+        result.setDate(result.getDate() + 7);
+      }
+      return result;
+    }
+    let targetDate = getNextSunday8pm();
     let winnerAnnounced = false;
     let countdownInterval = setInterval(updateCountdown, 1000);
     let currentWinner = null;
@@ -248,7 +260,7 @@ const speed = 4;
         b.el.style.display = 'flex';
       });
       winnerAnnounced = false;
-      targetDate = new Date(Date.now() + 10 * 1000);
+      targetDate = getNextSunday8pm();
       countdownInterval = setInterval(updateCountdown, 1000);
       updateCountdown();
     }


### PR DESCRIPTION
## Summary
- compute next Sunday 8pm and use as countdown target
- reset countdown to next Sunday 8pm after each drawing

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893c00c95d8832e9b1651b62e1cf93b